### PR TITLE
feat: add removeDeclarations option to strip properties from critical…

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,6 +29,6 @@ jobs:
                   cache: npm
             - run: npm install
             - run: npm run build
-            - run: npm test
             - run: npm run typecheck
             - run: npm run lint
+            - run: npm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,9 @@
 #!/usr/bin/env sh
 npx biome check --write --no-errors-on-unmatched --staged
+
+if ! git diff --quiet; then
+  echo ""
+  echo "Biome hat Dateien verändert. Änderungen prüfen, stagen und erneut committen:"
+  git diff --name-only
+  exit 1
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,7 +3,7 @@ npx biome check --write --no-errors-on-unmatched --staged
 
 if ! git diff --quiet; then
   echo ""
-  echo "Biome hat Dateien verändert. Änderungen prüfen, stagen und erneut committen:"
+  echo "Biome modified files. Review changes, stage them, and commit again:"
   git diff --name-only
   exit 1
 fi

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ The CLI usage is not implemented yet :scream:. At the moment there is no need of
 | keepSelectors           | Array                            | Optional. Every CSS Selector in this array will be kept as part of the critical css even if they are not part of it. You can use wildcards (%) to capture more rules with one entry. [Read more](#wildcards). Default: []        |
 | removeSelectors:        | Array                            | Optional. Every CSS Selector in this array will be removed of the critical css even if they are part of it. You can use wildcards (%) to capture more rules with one entry. [Read more](#wildcards). Default: []                 |
 | blockRequests           | Array                            | Optional. Some of the requests made by pages are an                                                                                                                                                                              |
+| removeDeclarations      | Array                            | Optional. CSS declarations to strip from the **critical** CSS and re-inject into the remaining CSS. Each entry can be a `string` (exact property name, case-insensitive), a `RegExp` (tested against the property name), or a `function (property, value) => boolean`. Default: [] |
 
 ### Browser options
 
@@ -252,6 +253,30 @@ This keepSelectors options will match every selector that begins with `.test` an
 .test .test2:before {
 } /* match */
 ```
+
+## removeDeclarations
+
+With `removeDeclarations` you can strip individual CSS properties from the critical CSS and have them automatically re-injected into the remaining CSS. This is useful for properties that are not needed above the fold — for example `cursor`, `transition`, or long-form border properties.
+
+Each entry in the array can be:
+
+- **String** — matches the property name exactly (case-insensitive)
+- **RegExp** — tested against the property name
+- **Function** — receives `(property, value)` and returns `true` to remove
+
+```javascript
+const { critical, rest } = await Crittr({
+    urls: urls,
+    css: css,
+    removeDeclarations: [
+        'cursor',                          // exact match
+        /^transition/,                     // all transition-* properties
+        (property, value) => value === '0' // any property with value "0"
+    ],
+});
+```
+
+Rules that become empty after stripping are removed from critical CSS entirely. The stripped declarations are always preserved in the remaining CSS so no styles are lost.
 
 ## FAQ :confused:
 

--- a/lib/classes/Crittr.class.ts
+++ b/lib/classes/Crittr.class.ts
@@ -732,7 +732,11 @@ class Crittr {
             }
 
             debug('evaluateUrl - cleaning up AST with criticalSelectorMap');
-            const [criticalAst, restAst] = this._cssTransformator.filterByMap(sourceAst, criticalSelectorsMap, this.options.removeDeclarations);
+            const [criticalAst, restAst] = this._cssTransformator.filterByMap(
+                sourceAst,
+                criticalSelectorsMap,
+                this.options.removeDeclarations,
+            );
             criticalAstObj = criticalAst;
             restAstObj = restAst;
             debug('evaluateUrl - cleaning up AST with criticalSelectorMap - END');

--- a/lib/classes/Crittr.class.ts
+++ b/lib/classes/Crittr.class.ts
@@ -94,6 +94,7 @@ class Crittr {
             screenshotNameGenerator: DEFAULTS.SCREENSHOT_NAME_GENERATOR,
             keepSelectors: [],
             removeSelectors: [],
+            removeDeclarations: [],
             blockRequests: [
                 'maps.gstatic.com',
                 'maps.googleapis.com',
@@ -731,7 +732,7 @@ class Crittr {
             }
 
             debug('evaluateUrl - cleaning up AST with criticalSelectorMap');
-            const [criticalAst, restAst] = this._cssTransformator.filterByMap(sourceAst, criticalSelectorsMap);
+            const [criticalAst, restAst] = this._cssTransformator.filterByMap(sourceAst, criticalSelectorsMap, this.options.removeDeclarations);
             criticalAstObj = criticalAst;
             restAstObj = restAst;
             debug('evaluateUrl - cleaning up AST with criticalSelectorMap - END');

--- a/lib/classes/CssTransformator.class.ts
+++ b/lib/classes/CssTransformator.class.ts
@@ -2,7 +2,7 @@ import log from '@dynamicabot/signales';
 import doDebug from 'debug';
 import deepmerge from 'deepmerge';
 import { parseCss, stringifyCss } from '../helper/cssAstAdapter.js';
-import type { AnyCssRule, CriticalSelectorsEntry, CssRule, CssStylesheet } from '../types.js';
+import type { AnyCssRule, CriticalSelectorsEntry, CssDeclaration, CssRule, CssStylesheet, DeclarationMatcher } from '../types.js';
 import Rule from './Rule.class.js';
 
 const debug = doDebug('crittr:css-transformator');
@@ -145,7 +145,7 @@ class CssTransformator {
             criticalSelectorsMap.set(ruleKey, rule.selectors);
         }
 
-        if (rule.type === 'rule' && rule.selectors.length === 0) {
+        if (rule.type === 'rule' && (rule.selectors ?? []).length === 0) {
             return null;
         }
 
@@ -178,11 +178,80 @@ class CssTransformator {
         return rule;
     }
 
+    private matchesDeclarationFilter(decl: CssDeclaration, matchers: DeclarationMatcher[]): boolean {
+        const property = decl.property.toLowerCase();
+        const value = decl.value ?? '';
+        return matchers.some(matcher => {
+            if (typeof matcher === 'string') return property === matcher.toLowerCase();
+            if (matcher instanceof RegExp) return matcher.test(property);
+            return matcher(property, value);
+        });
+    }
+
+    private findOrCreateGroupInRest(criticalGroupRule: AnyCssRule, restRules: AnyCssRule[]): RuleWithRules {
+        const groupId = this.getGroupRuleId(criticalGroupRule);
+        const existing = restRules.find(r => this.isGroupType(r) && this.getGroupRuleId(r) === groupId);
+        if (existing) return existing as RuleWithRules;
+
+        const newGroup = JSON.parse(JSON.stringify(criticalGroupRule)) as RuleWithRules;
+        newGroup.rules = [];
+        restRules.push(newGroup as AnyCssRule);
+        return newGroup;
+    }
+
+    private applyRemoveDeclarationsToRules(
+        criticalRules: AnyCssRule[],
+        restRules: AnyCssRule[],
+        removeDeclarations: DeclarationMatcher[],
+    ): void {
+        for (let i = criticalRules.length - 1; i >= 0; i--) {
+            const rule = criticalRules[i];
+
+            if (this.isGroupType(rule)) {
+                const groupRule = rule as RuleWithRules;
+                const restGroup = this.findOrCreateGroupInRest(rule, restRules);
+
+                this.applyRemoveDeclarationsToRules(
+                    groupRule.rules ?? [],
+                    restGroup.rules ?? [],
+                    removeDeclarations,
+                );
+
+                if ((groupRule.rules?.length ?? 0) === 0) {
+                    criticalRules.splice(i, 1);
+                }
+            } else if (rule.type === 'rule') {
+                const cssRule = rule as CssRule;
+                if (!cssRule.declarations?.length) continue;
+
+                const strippedDecls = cssRule.declarations.filter(d =>
+                    this.matchesDeclarationFilter(d, removeDeclarations)
+                );
+
+                if (strippedDecls.length > 0) {
+                    cssRule.declarations = cssRule.declarations.filter(d =>
+                        !this.matchesDeclarationFilter(d, removeDeclarations)
+                    );
+
+                    restRules.push({
+                        type: 'rule',
+                        selectors: [...(cssRule.selectors ?? [])],
+                        declarations: strippedDecls,
+                    } as CssRule);
+
+                    if (cssRule.declarations.length === 0) {
+                        criticalRules.splice(i, 1);
+                    }
+                }
+            }
+        }
+    }
+
     /**
      * Filters the AST Object with the `selectorMap` containing critical selectors.
      * Returns a tuple `[criticalAst, restAst]`. Does NOT mutate the input AST.
      */
-    filterByMap(ast: CssStylesheet, selectorMap: Map<string, CriticalSelectorsEntry>): [CssStylesheet, CssStylesheet] {
+    filterByMap(ast: CssStylesheet, selectorMap: Map<string, CriticalSelectorsEntry>, removeDeclarations: DeclarationMatcher[] = []): [CssStylesheet, CssStylesheet] {
         const _ast = JSON.parse(JSON.stringify(ast)) as CssStylesheet;
         const _astRest = JSON.parse(JSON.stringify(ast)) as CssStylesheet;
         const _astRoot = _ast.stylesheet;
@@ -210,6 +279,11 @@ class CssTransformator {
 
         _astRoot.rules = newRules;
         _astRestRoot.rules = restRules;
+
+        // Strip removeDeclarations from critical and re-inject into rest
+        if (removeDeclarations.length > 0) {
+            this.applyRemoveDeclarationsToRules(_astRoot.rules, _astRestRoot.rules, removeDeclarations);
+        }
 
         return [_ast, _astRest];
     }

--- a/lib/classes/CssTransformator.class.ts
+++ b/lib/classes/CssTransformator.class.ts
@@ -211,11 +211,7 @@ class CssTransformator {
                 const groupRule = rule as RuleWithRules;
                 const restGroup = this.findOrCreateGroupInRest(rule, restRules);
 
-                this.applyRemoveDeclarationsToRules(
-                    groupRule.rules ?? [],
-                    restGroup.rules ?? [],
-                    removeDeclarations,
-                );
+                this.applyRemoveDeclarationsToRules(groupRule.rules ?? [], restGroup.rules ?? [], removeDeclarations);
 
                 if ((groupRule.rules?.length ?? 0) === 0) {
                     criticalRules.splice(i, 1);
@@ -224,14 +220,10 @@ class CssTransformator {
                 const cssRule = rule as CssRule;
                 if (!cssRule.declarations?.length) continue;
 
-                const strippedDecls = cssRule.declarations.filter(d =>
-                    this.matchesDeclarationFilter(d, removeDeclarations)
-                );
+                const strippedDecls = cssRule.declarations.filter(d => this.matchesDeclarationFilter(d, removeDeclarations));
 
                 if (strippedDecls.length > 0) {
-                    cssRule.declarations = cssRule.declarations.filter(d =>
-                        !this.matchesDeclarationFilter(d, removeDeclarations)
-                    );
+                    cssRule.declarations = cssRule.declarations.filter(d => !this.matchesDeclarationFilter(d, removeDeclarations));
 
                     restRules.push({
                         type: 'rule',
@@ -251,7 +243,11 @@ class CssTransformator {
      * Filters the AST Object with the `selectorMap` containing critical selectors.
      * Returns a tuple `[criticalAst, restAst]`. Does NOT mutate the input AST.
      */
-    filterByMap(ast: CssStylesheet, selectorMap: Map<string, CriticalSelectorsEntry>, removeDeclarations: DeclarationMatcher[] = []): [CssStylesheet, CssStylesheet] {
+    filterByMap(
+        ast: CssStylesheet,
+        selectorMap: Map<string, CriticalSelectorsEntry>,
+        removeDeclarations: DeclarationMatcher[] = [],
+    ): [CssStylesheet, CssStylesheet] {
         const _ast = JSON.parse(JSON.stringify(ast)) as CssStylesheet;
         const _astRest = JSON.parse(JSON.stringify(ast)) as CssStylesheet;
         const _astRoot = _ast.stylesheet;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -39,6 +39,8 @@ export interface PuppeteerOptions {
     headless: boolean | 'shell';
 }
 
+export type DeclarationMatcher = string | RegExp | ((property: string, value: string) => boolean);
+
 export interface CrittrOptions {
     css?: string | null;
     urls: ReadonlyArray<string>;
@@ -56,6 +58,7 @@ export interface CrittrOptions {
     keepSelectors?: ReadonlyArray<string>;
     removeSelectors?: ReadonlyArray<string>;
     blockRequests?: ReadonlyArray<string>;
+    removeDeclarations?: ReadonlyArray<DeclarationMatcher>;
 }
 
 /**
@@ -81,6 +84,7 @@ export interface ResolvedCrittrOptions {
     keepSelectors: string[];
     removeSelectors: string[];
     blockRequests: string[];
+    removeDeclarations: DeclarationMatcher[];
 }
 
 export interface CrittrResult {

--- a/test/tests/remove_declarations.test.js
+++ b/test/tests/remove_declarations.test.js
@@ -1,0 +1,225 @@
+import { describe, expect, test } from 'vitest';
+import Crittr from '../../lib/classes/Crittr.class.js';
+import CssTransformator from '../../lib/classes/CssTransformator.class.js';
+
+const transformator = new CssTransformator();
+
+/**
+ * Build a selectorMap that marks every selector of every rule as critical.
+ * Used to ensure rules pass the selector filter so declaration filtering can be tested.
+ */
+function buildFullSelectorMap(ast) {
+    const map = new Map();
+    for (const rule of ast.stylesheet.rules) {
+        if (rule.type === 'rule') {
+            const key = rule.selectors.join(',');
+            map.set(key, { selectors: rule.selectors });
+        } else if ((rule.type === 'media' || rule.type === 'supports') && rule.rules) {
+            for (const inner of rule.rules) {
+                if (inner.type === 'rule') {
+                    const prefix = `${rule.type}${rule.media ?? rule.supports ?? ''}`;
+                    // Key matches Rule.generateRuleKey(inner, groupPrefix) — no separator
+                    const key = `${prefix}${inner.selectors.join(',')}`;
+                    map.set(key, { selectors: inner.selectors });
+                }
+            }
+        }
+    }
+    return map;
+}
+
+describe('removeDeclarations option', () => {
+    describe('string matcher', () => {
+        test('removes declaration by exact property name from critical', () => {
+            const css = '.foo { color: red; background: blue; }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap, ['color']);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).not.toContain('color');
+            expect(criticalCss).toContain('background');
+        });
+
+        test('is case-insensitive', () => {
+            const css = '.foo { COLOR: red; background: blue; }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap, ['color']);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).not.toContain('COLOR');
+            expect(criticalCss).toContain('background');
+        });
+
+        test('does not affect rest css', () => {
+            const css = '.foo { color: red; background: blue; }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [, rest] = transformator.filterByMap(ast, selectorMap, ['color']);
+            const restCss = transformator.getCssFromAst(rest);
+
+            expect(restCss).toContain('color');
+        });
+    });
+
+    describe('RegExp matcher', () => {
+        test('removes declarations matching regexp against property name', () => {
+            const css = '.foo { border-radius: 4px; border-color: red; background: blue; }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap, [/^border-/]);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).not.toContain('border-radius');
+            expect(criticalCss).not.toContain('border-color');
+            expect(criticalCss).toContain('background');
+        });
+    });
+
+    describe('function matcher', () => {
+        test('removes declarations where predicate returns true', () => {
+            const css = '.foo { cursor: pointer; color: red; background: blue; }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap, [
+                (property) => property === 'cursor',
+            ]);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).not.toContain('cursor');
+            expect(criticalCss).toContain('color');
+            expect(criticalCss).toContain('background');
+        });
+
+        test('receives both property and value', () => {
+            const css = '.foo { color: red; color: blue; background: blue; }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const seenArgs = [];
+            const [critical] = transformator.filterByMap(ast, selectorMap, [
+                (property, value) => {
+                    seenArgs.push({ property, value });
+                    return false;
+                },
+            ]);
+
+            expect(seenArgs.length).toBeGreaterThan(0);
+            expect(seenArgs[0]).toHaveProperty('property');
+            expect(seenArgs[0]).toHaveProperty('value');
+        });
+    });
+
+    describe('empty rule cleanup', () => {
+        test('removes rule from critical when all declarations are stripped', () => {
+            const css = '.foo { color: red; } .bar { background: blue; }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap, ['color']);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).not.toContain('.foo');
+            expect(criticalCss).toContain('.bar');
+        });
+
+        test('keeps rule in rest when all critical declarations are stripped', () => {
+            const css = '.foo { color: red; }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical, rest] = transformator.filterByMap(ast, selectorMap, ['color']);
+            const criticalCss = transformator.getCssFromAst(critical);
+            const restCss = transformator.getCssFromAst(rest);
+
+            expect(criticalCss).not.toContain('.foo');
+            expect(restCss).toContain('color');
+        });
+    });
+
+    describe('@media wrapper', () => {
+        test('filters declarations inside media query', () => {
+            const css = '@media (max-width: 800px) { .foo { color: red; background: blue; } }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap, ['color']);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).not.toContain('color');
+            expect(criticalCss).toContain('background');
+        });
+
+        test('removes empty @media rule when all inner declarations are stripped', () => {
+            const css = '@media (max-width: 800px) { .foo { color: red; } }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap, ['color']);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).not.toContain('@media');
+        });
+    });
+
+    describe('no-op when empty', () => {
+        test('leaves critical css unchanged when removeDeclarations is empty', () => {
+            const css = '.foo { color: red; background: blue; }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap, []);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).toContain('color');
+            expect(criticalCss).toContain('background');
+        });
+
+        test('leaves critical css unchanged when removeDeclarations is omitted', () => {
+            const css = '.foo { color: red; background: blue; }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).toContain('color');
+            expect(criticalCss).toContain('background');
+        });
+    });
+
+    describe('multiple matchers', () => {
+        test('removes declarations matching any of multiple matchers', () => {
+            const css = '.foo { color: red; cursor: pointer; background: blue; border-radius: 4px; }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap, ['color', 'cursor', /^border-/]);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).not.toContain('color');
+            expect(criticalCss).not.toContain('cursor');
+            expect(criticalCss).not.toContain('border-radius');
+            expect(criticalCss).toContain('background');
+        });
+    });
+});
+
+describe('Crittr constructor option threading', () => {
+    test('removeDeclarations is stored in resolved options', () => {
+        const matchers = ['color', /^border-/];
+        const instance = new Crittr({ urls: ['http://localhost'], removeDeclarations: matchers });
+        expect(instance.options.removeDeclarations).toEqual(matchers);
+    });
+
+    test('removeDeclarations defaults to empty array when omitted', () => {
+        const instance = new Crittr({ urls: ['http://localhost'] });
+        expect(instance.options.removeDeclarations).toEqual([]);
+    });
+});

--- a/test/tests/remove_declarations.test.js
+++ b/test/tests/remove_declarations.test.js
@@ -87,9 +87,7 @@ describe('removeDeclarations option', () => {
             const ast = transformator.getAst(css);
             const selectorMap = buildFullSelectorMap(ast);
 
-            const [critical] = transformator.filterByMap(ast, selectorMap, [
-                (property) => property === 'cursor',
-            ]);
+            const [critical] = transformator.filterByMap(ast, selectorMap, [property => property === 'cursor']);
             const criticalCss = transformator.getCssFromAst(critical);
 
             expect(criticalCss).not.toContain('cursor');
@@ -103,7 +101,7 @@ describe('removeDeclarations option', () => {
             const selectorMap = buildFullSelectorMap(ast);
 
             const seenArgs = [];
-            const [critical] = transformator.filterByMap(ast, selectorMap, [
+            const [_critical] = transformator.filterByMap(ast, selectorMap, [
                 (property, value) => {
                     seenArgs.push({ property, value });
                     return false;


### PR DESCRIPTION
Closes #52

  ## Summary
  - Adds `removeDeclarations` option to `CrittrOptions` accepting `string | RegExp | function` matchers
  - Matched declarations are stripped from critical CSS and re-injected into remaining CSS (no styles lost)
  - Empty rules and empty `@media`/`@supports` groups are cleaned up automatically
  - Documented in README (Options table + dedicated section with examples)

  ## Implementation
  Post-processing pass in `CssTransformator.applyRemoveDeclarationsToRules()` after both ASTs are fully built — necessary because rules that are 100% critical
  disappear from rest entirely during the split phase.

  ## Tests
  15 new tests in `test/tests/remove_declarations.test.js`: string/RegExp/function matchers, case-insensitivity, empty rule cleanup, `@media` recursion, no-op für
  leere Arrays, Konstruktor-Option-Threading.