### PR TITLE
feat: add excludeMediaQueries option to filter @media rules from crit…

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ The CLI usage is not implemented yet :scream:. At the moment there is no need of
 | removeSelectors:        | Array                            | Optional. Every CSS Selector in this array will be removed of the critical css even if they are part of it. You can use wildcards (%) to capture more rules with one entry. [Read more](#wildcards). Default: []                 |
 | blockRequests           | Array                            | Optional. Some of the requests made by pages are an                                                                                                                                                                              |
 | removeDeclarations      | Array                            | Optional. CSS declarations to strip from the **critical** CSS and re-inject into the remaining CSS. Each entry can be a `string` (exact property name, case-insensitive), a `RegExp` (tested against the property name), or a `function (property, value) => boolean`. Default: [] |
+| excludeMediaQueries     | Array                            | Optional. Exclude specific `@media` rules from critical CSS. Matched rules are moved to the rest CSS. Accepts strings (substring match, case-insensitive) or `RegExp` patterns. Default: `['print']` |
 
 ### Browser options
 
@@ -277,6 +278,38 @@ const { critical, rest } = await Crittr({
 ```
 
 Rules that become empty after stripping are removed from critical CSS entirely. The stripped declarations are always preserved in the remaining CSS so no styles are lost.
+
+## excludeMediaQueries
+
+With `excludeMediaQueries` you can prevent specific `@media` rules from appearing in the critical CSS output. Matched rules are moved to the remaining CSS — no styles are lost.
+
+By default, `@media print` rules are excluded because print styles are never needed above the fold. Set the option to `[]` to opt out of this behavior entirely.
+
+Each entry in the array can be:
+
+- **String** — matched as a case-insensitive substring of the media query string (e.g. `'print'` matches `@media print`)
+- **RegExp** — tested against the media query string (e.g. `/print/i`)
+
+```javascript
+const { critical, rest } = await Crittr({
+    urls: urls,
+    css: css,
+    excludeMediaQueries: [
+        'print',         // excludes @media print (default)
+        /^screen/,       // excludes @media screen ...
+    ],
+});
+```
+
+To disable the default exclusion of `@media print`:
+
+```javascript
+const { critical, rest } = await Crittr({
+    urls: urls,
+    css: css,
+    excludeMediaQueries: [],
+});
+```
 
 ## FAQ :confused:
 

--- a/lib/classes/Crittr.class.ts
+++ b/lib/classes/Crittr.class.ts
@@ -95,6 +95,7 @@ class Crittr {
             keepSelectors: [],
             removeSelectors: [],
             removeDeclarations: [],
+            excludeMediaQueries: ['print'],
             blockRequests: [
                 'maps.gstatic.com',
                 'maps.googleapis.com',
@@ -736,6 +737,7 @@ class Crittr {
                 sourceAst,
                 criticalSelectorsMap,
                 this.options.removeDeclarations,
+                this.options.excludeMediaQueries,
             );
             criticalAstObj = criticalAst;
             restAstObj = restAst;

--- a/lib/classes/CssTransformator.class.ts
+++ b/lib/classes/CssTransformator.class.ts
@@ -2,7 +2,15 @@ import log from '@dynamicabot/signales';
 import doDebug from 'debug';
 import deepmerge from 'deepmerge';
 import { parseCss, stringifyCss } from '../helper/cssAstAdapter.js';
-import type { AnyCssRule, CriticalSelectorsEntry, CssDeclaration, CssRule, CssStylesheet, DeclarationMatcher } from '../types.js';
+import type {
+    AnyCssRule,
+    CriticalSelectorsEntry,
+    CssDeclaration,
+    CssMediaRule,
+    CssRule,
+    CssStylesheet,
+    DeclarationMatcher,
+} from '../types.js';
 import Rule from './Rule.class.js';
 
 const debug = doDebug('crittr:css-transformator');
@@ -239,6 +247,27 @@ class CssTransformator {
         }
     }
 
+    private matchesExcludedMediaQuery(media: string, patterns: (string | RegExp)[]): boolean {
+        return patterns.some(pattern => {
+            if (typeof pattern === 'string') return media.toLowerCase().includes(pattern.toLowerCase());
+            return pattern.test(media);
+        });
+    }
+
+    private applyExcludeMediaQueriesToRules(criticalRules: AnyCssRule[], restRules: AnyCssRule[], patterns: (string | RegExp)[]): void {
+        for (let i = criticalRules.length - 1; i >= 0; i--) {
+            const rule = criticalRules[i];
+
+            if (rule.type === 'media' && this.matchesExcludedMediaQuery((rule as CssMediaRule).media, patterns)) {
+                criticalRules.splice(i, 1);
+                restRules.unshift(rule);
+            } else if (this.isGroupType(rule)) {
+                const groupRule = rule as RuleWithRules;
+                this.applyExcludeMediaQueriesToRules(groupRule.rules ?? [], restRules, patterns);
+            }
+        }
+    }
+
     /**
      * Filters the AST Object with the `selectorMap` containing critical selectors.
      * Returns a tuple `[criticalAst, restAst]`. Does NOT mutate the input AST.
@@ -247,6 +276,7 @@ class CssTransformator {
         ast: CssStylesheet,
         selectorMap: Map<string, CriticalSelectorsEntry>,
         removeDeclarations: DeclarationMatcher[] = [],
+        excludeMediaQueries: (string | RegExp)[] = [],
     ): [CssStylesheet, CssStylesheet] {
         const _ast = JSON.parse(JSON.stringify(ast)) as CssStylesheet;
         const _astRest = JSON.parse(JSON.stringify(ast)) as CssStylesheet;
@@ -279,6 +309,11 @@ class CssTransformator {
         // Strip removeDeclarations from critical and re-inject into rest
         if (removeDeclarations.length > 0) {
             this.applyRemoveDeclarationsToRules(_astRoot.rules, _astRestRoot.rules, removeDeclarations);
+        }
+
+        // Move excluded @media rules from critical to rest
+        if (excludeMediaQueries.length > 0) {
+            this.applyExcludeMediaQueriesToRules(_astRoot.rules, _astRestRoot.rules, excludeMediaQueries);
         }
 
         return [_ast, _astRest];

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -59,6 +59,7 @@ export interface CrittrOptions {
     removeSelectors?: ReadonlyArray<string>;
     blockRequests?: ReadonlyArray<string>;
     removeDeclarations?: ReadonlyArray<DeclarationMatcher>;
+    excludeMediaQueries?: ReadonlyArray<string | RegExp>;
 }
 
 /**
@@ -85,6 +86,7 @@ export interface ResolvedCrittrOptions {
     removeSelectors: string[];
     blockRequests: string[];
     removeDeclarations: DeclarationMatcher[];
+    excludeMediaQueries: (string | RegExp)[];
 }
 
 export interface CrittrResult {

--- a/test/tests/exclude_media_queries.test.js
+++ b/test/tests/exclude_media_queries.test.js
@@ -1,0 +1,184 @@
+import { describe, expect, test } from 'vitest';
+import Crittr from '../../lib/classes/Crittr.class.js';
+import CssTransformator from '../../lib/classes/CssTransformator.class.js';
+
+const transformator = new CssTransformator();
+
+/**
+ * Build a selectorMap that marks every selector of every rule as critical.
+ * Used to ensure rules pass the selector filter so media-query filtering can be tested.
+ */
+function buildFullSelectorMap(ast) {
+    const map = new Map();
+    for (const rule of ast.stylesheet.rules) {
+        if (rule.type === 'rule') {
+            const key = rule.selectors.join(',');
+            map.set(key, { selectors: rule.selectors });
+        } else if ((rule.type === 'media' || rule.type === 'supports') && rule.rules) {
+            for (const inner of rule.rules) {
+                if (inner.type === 'rule') {
+                    const prefix = `${rule.type}${rule.media ?? rule.supports ?? ''}`;
+                    const key = `${prefix}${inner.selectors.join(',')}`;
+                    map.set(key, { selectors: inner.selectors });
+                }
+            }
+        }
+    }
+    return map;
+}
+
+describe('excludeMediaQueries option', () => {
+    describe('default behavior', () => {
+        test('@media print is excluded from critical by default', () => {
+            const css = '.foo { color: red; } @media print { .foo { color: black; } }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap, [], ['print']);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).not.toContain('@media print');
+            expect(criticalCss).toContain('.foo');
+        });
+
+        test('@media print is moved to rest when excluded', () => {
+            const css = '.foo { color: red; } @media print { .foo { color: black; } }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [, rest] = transformator.filterByMap(ast, selectorMap, [], ['print']);
+            const restCss = transformator.getCssFromAst(rest);
+
+            expect(restCss).toContain('@media print');
+        });
+    });
+
+    describe('opt-out with empty array', () => {
+        test('@media print stays in critical when excludeMediaQueries is empty', () => {
+            const css = '.foo { color: red; } @media print { .foo { color: black; } }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap, [], []);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).toContain('@media print');
+        });
+
+        test('@media print stays in critical when excludeMediaQueries is omitted', () => {
+            const css = '.foo { color: red; } @media print { .foo { color: black; } }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).toContain('@media print');
+        });
+    });
+
+    describe('string pattern', () => {
+        test('custom string pattern excludes matching @media rule', () => {
+            const css = '.foo { color: red; } @media screen { .foo { color: blue; } }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap, [], ['screen']);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).not.toContain('@media screen');
+        });
+
+        test('string match is case-insensitive', () => {
+            const css = '@media PRINT { .foo { color: black; } }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap, [], ['print']);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).not.toContain('@media');
+        });
+    });
+
+    describe('RegExp pattern', () => {
+        test('RegExp pattern excludes matching @media rule', () => {
+            const css = '.foo { color: red; } @media print { .foo { color: black; } }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap, [], [/print/i]);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).not.toContain('@media print');
+        });
+
+        test('RegExp is case-insensitive when flag is set', () => {
+            const css = '@media PRINT { .foo { color: black; } }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap, [], [/print/i]);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).not.toContain('@media');
+        });
+    });
+
+    describe('non-matching @media rules', () => {
+        test('@media (min-width: 800px) stays in critical when not excluded', () => {
+            const css = '@media (min-width: 800px) { .foo { color: red; } }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [critical] = transformator.filterByMap(ast, selectorMap, [], ['print']);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).toContain('@media');
+            expect(criticalCss).toContain('min-width');
+        });
+
+        test('non-excluded @media rule is not moved to rest', () => {
+            const css = '@media (min-width: 800px) { .foo { color: red; } }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            // rest already has a copy; critical should keep its own
+            const [critical] = transformator.filterByMap(ast, selectorMap, [], ['print']);
+            const criticalCss = transformator.getCssFromAst(critical);
+
+            expect(criticalCss).toContain('min-width');
+        });
+    });
+
+    describe('rest CSS receives excluded rule', () => {
+        test('excluded @media rule is present in rest CSS', () => {
+            const css = '.foo { color: red; } @media print { .bar { font-size: 12pt; } }';
+            const ast = transformator.getAst(css);
+            const selectorMap = buildFullSelectorMap(ast);
+
+            const [, rest] = transformator.filterByMap(ast, selectorMap, [], ['print']);
+            const restCss = transformator.getCssFromAst(rest);
+
+            expect(restCss).toContain('@media print');
+            expect(restCss).toContain('font-size');
+        });
+    });
+});
+
+describe('Crittr constructor option threading', () => {
+    test('excludeMediaQueries defaults to ["print"]', () => {
+        const instance = new Crittr({ urls: ['http://localhost'] });
+        expect(instance.options.excludeMediaQueries).toEqual(['print']);
+    });
+
+    test('excludeMediaQueries is stored in resolved options', () => {
+        const instance = new Crittr({ urls: ['http://localhost'], excludeMediaQueries: [/print/i, 'screen'] });
+        expect(instance.options.excludeMediaQueries).toEqual([/print/i, 'screen']);
+    });
+
+    test('excludeMediaQueries can be set to empty array to opt out', () => {
+        const instance = new Crittr({ urls: ['http://localhost'], excludeMediaQueries: [] });
+        expect(instance.options.excludeMediaQueries).toEqual([]);
+    });
+});


### PR DESCRIPTION
Closes #39

  @media print rules have no relevance for above-the-fold rendering and should not appear in critical CSS. This PR introduces a new excludeMediaQueries option that
  filters entire @media blocks out of the critical CSS output and moves them to the rest CSS instead.

  Default behaviour (no config change needed): @media print is excluded automatically.

  What changed

  - New option excludeMediaQueries — accepts an array of string (substring match, case-insensitive) or RegExp patterns
  - Default: ['print'] — fixes the reported issue out-of-the-box without any configuration
  - Excluded @media blocks are moved to rest, not dropped
  - Implemented as a post-processing pass (same architecture as removeDeclarations) to avoid interference with selector map building
  - 14 new tests covering default behaviour, opt-out, string patterns, RegExp patterns, and rest CSS verification

  Usage

  // Default — @media print excluded automatically
  const crittr = new Crittr({ urls: ['https://example.com'] });

  // Opt out
  const crittr = new Crittr({
    urls: ['https://example.com'],
    excludeMediaQueries: [],
  });

  // Custom patterns
  const crittr = new Crittr({
    urls: ['https://example.com'],
    excludeMediaQueries: ['print', /speech/i],
  });

  Test plan

  - @media print absent from critical CSS with default config
  - @media print present in rest CSS after exclusion
  - excludeMediaQueries: [] keeps @media print in critical (opt-out works)
  - String patterns use case-insensitive substring match
  - RegExp patterns work correctly
  - Non-matching @media rules remain in critical unaffected
  - All 76 existing + new tests pass